### PR TITLE
Add methods get_neighboring_vertices and jitter_vertices to SurfaceEvolver

### DIFF
--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -66,7 +66,7 @@ def test_fit_last_furrow(furrow):
     r_value = r2_score(tensions_df['gt'].values / tensions_df['gt'].mean(), 
                                 tensions_df['stress'].values)
     print("Final furrow", r_value)
-    assert 1 > r_value > 0.93
+    assert 1 > r_value > 0.99
 
 
 def test_fit_noisy_last_furrow(noisy_last_furrow):


### PR DESCRIPTION
### Change log
- Add public method `get_neighboring_vertices` to `surface_evolver.SurfaceEvolver`
- Add public method `jitter_vertices` to `surface_evolver.SurfaceEvolver`
- Add pytest fixture `noisy_last_furrow` and `test_fit_noisy_last_furrow`
- Set lower bound for R^2 value in  `test_fit_last_furrow` to `0.99`